### PR TITLE
Assign numbers minesweeper

### DIFF
--- a/src/main/java/org/korecky/interview/AssignNumbersMinesweeper.java
+++ b/src/main/java/org/korecky/interview/AssignNumbersMinesweeper.java
@@ -1,5 +1,7 @@
 package org.korecky.interview;
 
+import java.util.Arrays;
+
 public class AssignNumbersMinesweeper {
 
 //	Assign Numbers in Minesweeper (Java)
@@ -24,6 +26,8 @@ public class AssignNumbersMinesweeper {
 
 	public static int[][] mineSweeper(int[][] bombs, int numRows, int numCols) {
 		int[][] field = new int[numRows][numCols];
+		for (int[] row: field)
+			Arrays.fill(row, 0);
 		return field;
 	}
 }

--- a/src/main/java/org/korecky/interview/AssignNumbersMinesweeper.java
+++ b/src/main/java/org/korecky/interview/AssignNumbersMinesweeper.java
@@ -4,30 +4,36 @@ import java.util.Arrays;
 
 public class AssignNumbersMinesweeper {
 
-//	Assign Numbers in Minesweeper (Java)
-//	Implement a function that assigns correct numbers in a field of Minesweeper, which is represented as a 2 dimensional array.
-//
-//	Example: The size of the field is 3x4, and there are bombs at the positions [0, 0] (row index = 0, column index = 0) and [0, 1] (row index = 0, column index = 1).
-//
-//	Then, the resulting field should be:
-//			[[-1, -1, 1, 0],
-//			[2, 2, 1, 0],
-//			[0, 0, 0, 0]]
-//
-//	Your function should return the resulting 2D array after taking the following three arguments:
-//	1) bombs: A list of bomb locations.  Given as an array of arrays.  Example: [[0, 0], [0, 1]] ([row index = 0, column index = 0], [row index = 0, column index = 1].  Assume that there are no duplicates.
-//	2) num_rows: The number of rows in the resulting field.
-//	3) num_columns: The number of columns in the resulting field.
+	//	Assign Numbers in Minesweeper (Java)
+	//	Implement a function that assigns correct numbers in a field of Minesweeper, which is represented as a 2 dimensional array.
+	//
+	//	Example: The size of the field is 3x4, and there are bombs at the positions [0, 0] (row index = 0, column index = 0) and [0, 1] (row index = 0, column index = 1).
+	//
+	//	Then, the resulting field should be:
+	//			[[-1, -1, 1, 0],
+	//			[2, 2, 1, 0],
+	//			[0, 0, 0, 0]]
+	//
+	//	Your function should return the resulting 2D array after taking the following three arguments:
+	//	1) bombs: A list of bomb locations.  Given as an array of arrays.  Example: [[0, 0], [0, 1]] ([row index = 0, column index = 0], [row index = 0, column index = 1].  Assume that there are no duplicates.
+	//	2) num_rows: The number of rows in the resulting field.
+	//	3) num_columns: The number of columns in the resulting field.
 
-//	In the resulting field:
-//	- (-1) represents that there is a bomb in that location.
-//  - (1, 2, 3...) etc. represents that there are 1, 2, 3... etc. bombs in the surrounding cells (including diagonally adjacent cells).
-//	- (0) represents that there are no bombs in the surrounding cells.
+	//	In the resulting field:
+	//	- (-1) represents that there is a bomb in that location.
+	//  - (1, 2, 3...) etc. represents that there are 1, 2, 3... etc. bombs in the surrounding cells (including diagonally adjacent cells).
+	//	- (0) represents that there are no bombs in the surrounding cells.
 
 	public static int[][] mineSweeper(int[][] bombs, int numRows, int numCols) {
+		// Create field with 0 value
 		int[][] field = new int[numRows][numCols];
-		for (int[] row: field)
+		for (int[] row : field)
 			Arrays.fill(row, 0);
+
+		// Fill bombs
+		for (int[] bomb : bombs) {
+			field[bomb[0]][bomb[1]] = -1;
+		}
 		return field;
 	}
 }

--- a/src/main/java/org/korecky/interview/AssignNumbersMinesweeper.java
+++ b/src/main/java/org/korecky/interview/AssignNumbersMinesweeper.java
@@ -1,0 +1,29 @@
+package org.korecky.interview;
+
+public class AssignNumbersMinesweeper {
+
+//	Assign Numbers in Minesweeper (Java)
+//	Implement a function that assigns correct numbers in a field of Minesweeper, which is represented as a 2 dimensional array.
+//
+//	Example: The size of the field is 3x4, and there are bombs at the positions [0, 0] (row index = 0, column index = 0) and [0, 1] (row index = 0, column index = 1).
+//
+//	Then, the resulting field should be:
+//			[[-1, -1, 1, 0],
+//			[2, 2, 1, 0],
+//			[0, 0, 0, 0]]
+//
+//	Your function should return the resulting 2D array after taking the following three arguments:
+//	1) bombs: A list of bomb locations.  Given as an array of arrays.  Example: [[0, 0], [0, 1]] ([row index = 0, column index = 0], [row index = 0, column index = 1].  Assume that there are no duplicates.
+//	2) num_rows: The number of rows in the resulting field.
+//	3) num_columns: The number of columns in the resulting field.
+
+//	In the resulting field:
+//	- (-1) represents that there is a bomb in that location.
+//  - (1, 2, 3...) etc. represents that there are 1, 2, 3... etc. bombs in the surrounding cells (including diagonally adjacent cells).
+//	- (0) represents that there are no bombs in the surrounding cells.
+
+	public static int[][] mineSweeper(int[][] bombs, int numRows, int numCols) {
+		int[][] field = new int[numRows][numCols];
+		return field;
+	}
+}

--- a/src/main/java/org/korecky/interview/AssignNumbersMinesweeper.java
+++ b/src/main/java/org/korecky/interview/AssignNumbersMinesweeper.java
@@ -32,7 +32,22 @@ public class AssignNumbersMinesweeper {
 
 		// Fill bombs
 		for (int[] bomb : bombs) {
-			field[bomb[0]][bomb[1]] = -1;
+			int bombX = bomb[0];
+			int bombY = bomb[1];
+			field[bombX][bombY] = -1;
+			for (int x = bombX - 1; x <= bombX + 1; x++) {
+				if ((x >= 0) && (x < numRows)) {
+					for (int y = bombY - 1; y <= bombY + 1; y++) {
+						if ((y >= 0) && (y < numCols)) {
+							int value = field[x][y];
+							if (value != -1) {
+								value++;
+								field[x][y] = value;
+							}
+						}
+					}
+				}
+			}
 		}
 		return field;
 	}

--- a/src/test/java/org/korecky/interview/AssignNumbersMinesweeperTest.java
+++ b/src/test/java/org/korecky/interview/AssignNumbersMinesweeperTest.java
@@ -1,0 +1,26 @@
+package org.korecky.interview;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class AssignNumbersMinesweeperTest {
+
+	@Test
+	void mineSweeper() {
+		int[][] bombs1 = {{0, 2}, {2, 0}};
+		int[][] expResult1 = {{0, 1, -1}, {1, 2, 1}, {-1, 1, 0}};
+		int[][] result1 = AssignNumbersMinesweeper.mineSweeper(bombs1, 3, 3);
+		assertArrayEquals(expResult1, result1);
+
+		int[][] bombs2 = {{0, 0}, {0, 1}, {1, 2}};
+		int[][] expResult2 = {{-1, -1, 2, 1}, {2, 3, -1, 1}, {0, 1, 1, 1}};
+		int[][] result2 = AssignNumbersMinesweeper.mineSweeper(bombs2, 3, 4);
+		assertArrayEquals(expResult2, result2);
+
+		int[][] bombs3 = {{1, 1}, {1, 2}, {2, 2}, {4, 3}};
+		int[][] expResult3 = {{1, 2, 2, 1, 0}, {1, -1, -1, 2, 0}, {1, 3, -1, 2, 0}, {0, 1, 2, 2, 1}, {0, 0, 1, -1, 1}};
+		int[][] result3 = AssignNumbersMinesweeper.mineSweeper(bombs3, 5, 5);
+		assertArrayEquals(expResult3, result3);
+	}
+}


### PR DESCRIPTION
Assign Numbers in Minesweeper (Java)
Implement a function that assigns correct numbers in a field of Minesweeper, which is represented as a 2 dimensional array.

Example: The size of the field is 3x4, and there are bombs at the positions [0, 0] (row index = 0, column index = 0) and [0, 1] (row index = 0, column index = 1).

Then, the resulting field should be:
        [[-1, -1, 1, 0],
        [2, 2, 1, 0],
        [0, 0, 0, 0]]

Your function should return the resulting 2D array after taking the following three arguments:
1) bombs: A list of bomb locations.  Given as an array of arrays.  Example: [[0, 0], [0, 1]] ([row index = 0, column index = 0], [row index = 0, column index = 1].  Assume that there are no duplicates.
2) num_rows: The number of rows in the resulting field.
3) num_columns: The number of columns in the resulting field.

In the resulting field:
- (-1) represents that there is a bomb in that location.
- (1, 2, 3...) etc. represents that there are 1, 2, 3... etc. bombs in the surrounding cells (including diagonally adjacent cells).
- (0) represents that there are no bombs in the surrounding cells.