### PR TITLE
N-th Element of a Linked List (Java)

### DIFF
--- a/src/main/java/org/korecky/interview/linkedlists/Node.java
+++ b/src/main/java/org/korecky/interview/linkedlists/Node.java
@@ -1,0 +1,19 @@
+package org.korecky.interview.linkedlists;
+
+public class Node {
+	private final int value;
+	private final Node child;
+
+	public Node(int value, Node child) {
+		this.value = value;
+		this.child = child;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	public Node getChild() {
+		return child;
+	}
+}

--- a/src/main/java/org/korecky/interview/linkedlists/NthElementOfLinkedList.java
+++ b/src/main/java/org/korecky/interview/linkedlists/NthElementOfLinkedList.java
@@ -14,6 +14,20 @@ public class NthElementOfLinkedList {
 	// If the given n is larger than the number of nodes in the list, return null / None.
 
 	public static Node nthFromLast(Node head, int n) {
-		return head;
+		Node right = head;
+		Node left = head;
+
+		for (int i = 0; i < n; i++) {
+			if (right == null)
+				return null;
+			right = right.getChild();
+		}
+
+		while (right != null) {
+			right = right.getChild();
+			left = left.getChild();
+		}
+
+		return left;
 	}
 }

--- a/src/main/java/org/korecky/interview/linkedlists/NthElementOfLinkedList.java
+++ b/src/main/java/org/korecky/interview/linkedlists/NthElementOfLinkedList.java
@@ -1,0 +1,19 @@
+package org.korecky.interview.linkedlists;
+
+public class NthElementOfLinkedList {
+
+	// N-th Element of a Linked List (Java)
+	//
+	// Implement a function that finds the nth node in a linked list, counting from the end.
+	// Your function should take a linked list (its head element) and n, a positive integer as its arguments.
+	// Examples:
+	// head = 7 -> 6 -> 5 -> 4 -> 3 -> 2 -> 1 -> (null / None)
+	// The third element of head counting from the end is 3.
+	// head2 = 1 -> 2 -> 3 -> 4 -> (null / None)
+	// The fourth element of head2 counting from the end is 1.
+	// If the given n is larger than the number of nodes in the list, return null / None.
+
+	public static Node nthFromLast(Node head, int n) {
+		return head;
+	}
+}

--- a/src/test/java/org/korecky/interview/linkedlists/NthElementOfLinkedListTest.java
+++ b/src/test/java/org/korecky/interview/linkedlists/NthElementOfLinkedListTest.java
@@ -1,0 +1,34 @@
+package org.korecky.interview.linkedlists;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class NthElementOfLinkedListTest {
+
+	@Test
+	void nthFromLast() {
+
+		// head = 7 -> 6 -> 5 -> 4 -> 3 -> 2 -> 1 -> (null)
+		Node current = new Node(1, null);
+		for (int i = 2; i < 8; i++) {
+			current = new Node(i, current);
+		}
+		Node head = current;
+
+		// head2 = 1 -> 2 -> 3 -> 4 -> (null)
+		Node current2 = new Node(4, null);
+		for (int i = 3; i > 0; i--) {
+			current2 = new Node(i, current2);
+		}
+		Node head2 = current2;
+
+
+		assertEquals(1, NthElementOfLinkedList.nthFromLast(head, 1));
+		assertEquals(5, NthElementOfLinkedList.nthFromLast(head, 5));
+		assertEquals(3, NthElementOfLinkedList.nthFromLast(head2, 2));
+		assertEquals(1, NthElementOfLinkedList.nthFromLast(head2, 4));
+		assertEquals(null, NthElementOfLinkedList.nthFromLast(null, 5));
+		assertEquals(null, NthElementOfLinkedList.nthFromLast(null, 1));
+	}
+}

--- a/src/test/java/org/korecky/interview/linkedlists/NthElementOfLinkedListTest.java
+++ b/src/test/java/org/korecky/interview/linkedlists/NthElementOfLinkedListTest.java
@@ -24,10 +24,10 @@ class NthElementOfLinkedListTest {
 		Node head2 = current2;
 
 
-		assertEquals(1, NthElementOfLinkedList.nthFromLast(head, 1));
-		assertEquals(5, NthElementOfLinkedList.nthFromLast(head, 5));
-		assertEquals(3, NthElementOfLinkedList.nthFromLast(head2, 2));
-		assertEquals(1, NthElementOfLinkedList.nthFromLast(head2, 4));
+		assertEquals(1, NthElementOfLinkedList.nthFromLast(head, 1).getValue());
+		assertEquals(5, NthElementOfLinkedList.nthFromLast(head, 5).getValue());
+		assertEquals(3, NthElementOfLinkedList.nthFromLast(head2, 2).getValue());
+		assertEquals(1, NthElementOfLinkedList.nthFromLast(head2, 4).getValue());
 		assertEquals(null, NthElementOfLinkedList.nthFromLast(null, 5));
 		assertEquals(null, NthElementOfLinkedList.nthFromLast(null, 1));
 	}


### PR DESCRIPTION
Implement a function that finds the nth node in a linked list, counting from the end.
Your function should take a linked list (its head element) and n, a positive integer as its arguments.
Examples:
head = 7 -> 6 -> 5 -> 4 -> 3 -> 2 -> 1 -> (null / None)
The third element of head counting from the end is 3.
head2 = 1 -> 2 -> 3 -> 4 -> (null / None)
The fourth element of head2 counting from the end is 1.
If the given n is larger than the number of nodes in the list, return null / None.